### PR TITLE
Add noopener to external links using gatsby-remark-external-links

### DIFF
--- a/@larsroettig-dev/theme/gatsby-config.js
+++ b/@larsroettig-dev/theme/gatsby-config.js
@@ -63,7 +63,7 @@ module.exports = (themeOptions) => {
               resolve: 'gatsby-remark-external-links',
               options: {
                 target: '_blank',
-                rel: 'noreferrer',
+                rel: 'noopener noreferrer',
               },
             },
           ],
@@ -84,7 +84,7 @@ module.exports = (themeOptions) => {
               resolve: 'gatsby-remark-external-links',
               options: {
                 target: '_blank',
-                rel: 'noreferrer',
+                rel: 'noopener noreferrer',
               },
             },
           ],


### PR DESCRIPTION
This prevents tabnabbing attacks by removing the opener property from
the window object of the opened tab.

See https://mathiasbynens.github.io/rel-noopener/ for further
information.